### PR TITLE
Update triangle_indicator.dart to fix accentColor deprecated

### DIFF
--- a/lib/src/indicators/triangle_indicator.dart
+++ b/lib/src/indicators/triangle_indicator.dart
@@ -17,7 +17,7 @@ class TriangleIndicator extends StatelessWidget {
         width: 36,
         height: 36,
         child: _Triangle(
-          color: color ?? theme.accentColor,
+          color: color ?? theme.colorScheme.secondary,
           elevation: 2,
         ),
       ),


### PR DESCRIPTION
You have already fixed the issue in rectangle_indicator.dart but there was still an issue in triangle_indicator.dart

I have fixed it. Please review and accept this PR so it can get incorporated into your PR to the original repo.